### PR TITLE
Lock gh actions versions in CI Pipelines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,13 +10,13 @@ jobs:
     steps:
       - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e #v1
         with:
           node-version: '10'
 
       - name: Fetch changes
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
 
       - name: Setup CKEditor 4 testing environment
         run: |
@@ -31,7 +31,7 @@ jobs:
 
       - name: Checkout bender test runner
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
         with:
           path: ckeditor4-benderjs-runner
           repository: ckeditor/ckeditor4-benderjs-runner


### PR DESCRIPTION
```
Lock gh actions versions in CI Pipelines

This PR gh actions (exact sha) versions in CI Pipelines.

Recent supply chain attacks in popular tools (Trivy, LiteLLM, axios) are 
concerning. There might be more such attacks.

Most of our CI pipelines that use public actions (in case of Github 
Actions workflows) or CircleCI orbs are not locked versions. This means 
that if any of these packages would be released and would be vulnerable, 
our jobs would pull these vulnerable versions. We need to lock the versions to 
protect ourselfs from these kind of attacks.

The sha commits in PR can be resolved and verified in the following way:

there are lightweight tags and they point directly to a sha commit, 
so we can use the sha of the tag itself.

But there are also annotated tags, which are separate git objects and 
they are pointing to commit and have their own sha different from commit.
 
Get the SHA commit for example for configure-aws-credentials@v4:
git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4^{}
result

^{} - is automatically derefrerrencing annotated tag to commit SHA, if
result is empty then the tag is not annotated but lightweight -> then:

git ls-remote https://github.com/actions/setup-node refs/tags/v4

gives you the commit sha directly but for 
configure-aws-credentials@v4
git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4
gives us the sha of the tag itself, not the commit. 
That's why we need to try dereference the tag first and dereference is 
empty then sha of tag is sha of commit itself. So verification:
1) if 
git ls-remote https://github.com/<org>/<action> refs/tags/<version>^{}
gives result, use it, if not, then:
2) git ls-remote https://github.com/<org>/<action> refs/tags/<version>
use this result.

Touches: https://tiugotech.atlassian.net/browse/TD-1704
```
Touches: https://tiugotech.atlassian.net/browse/TD-1704



<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<ISSUE_NUMBER>](https://github.com/ckeditor/ckeditor4/issues/<ISSUE_NUMBER>): Describe the purpose of the pull request in a few simple sentences.
```

## What changes did you make?

*Give an overview…*

## Which issues does your PR resolve?

Closes #<ISSUE_NUMBER>.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
